### PR TITLE
Add attribute to limit dragging within a container

### DIFF
--- a/example/simple.html
+++ b/example/simple.html
@@ -29,6 +29,7 @@
                     makeClone: true,
                     sourceClass: "pendingDrop",
                     dropClass: "highlight",
+                    container: $('.content'),
                     canDrag: function($src) {
                         return true;
                     },


### PR DESCRIPTION
This attribute limits the movement within a DOM element. Included test case (try to drag letters M-R to the right/left extremes of the page).

On an unrelated note, the vertical position of the page seems to be wrong. If the page has a non-zero scroll position (i.e: set a really tall chrome console and scroll the page contents down) the drop behavior gets broken.
